### PR TITLE
fix(#17): prevent pages from being generated for meta files

### DIFF
--- a/_source/_meta/htaccess.njk
+++ b/_source/_meta/htaccess.njk
@@ -1,5 +1,6 @@
 ---
 permalink: .htaccess
+eleventyExcludeFromCollections: true
 ---
 
 <IfModule mod_rewrite.c>

--- a/_source/_meta/robots.njk
+++ b/_source/_meta/robots.njk
@@ -1,5 +1,6 @@
 ---
 permalink: robots.txt
+eleventyExcludeFromCollections: true
 ---
 
 User-agent: *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Elf.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Moiety Studio 11ty project template",
   "main": "/_source/assets/app.js",
   "scripts": {


### PR DESCRIPTION
Stops pages from being generated for `robots.txt` and `.htaccess`

Fixes #17 