### PR TITLE
feat(#22): page description

### DIFF
--- a/_source/_data/globals.json
+++ b/_source/_data/globals.json
@@ -1,0 +1,4 @@
+{
+  "title": "Elf.",
+  "description": "Elf is an 11ty project template to help you start your next 11ty project with ease."
+}

--- a/_source/_data/globals.json
+++ b/_source/_data/globals.json
@@ -1,4 +1,7 @@
 {
-  "title": "Elf.",
+  "title": {
+    "short": "Elf.",
+    "long": "Elf. an 11ty project template"
+  },
   "description": "Elf is an 11ty project template to help you start your next 11ty project with ease."
 }

--- a/_source/_includes/layouts/base.njk
+++ b/_source/_includes/layouts/base.njk
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% if title %}
-    <title>{{ title }} - Elf</title>
+    <title>{{ title }} - {{ globals.title.short }}</title>
     {% else %}
-    <title>Elf. an 11ty project template</title>
+    <title>{{ globals.title.long }}</title>
     {% endif %}
     <meta name="description" content="{{ globals.description }}">
     <link rel="stylesheet" href="/assets/core.css">

--- a/_source/_includes/layouts/base.njk
+++ b/_source/_includes/layouts/base.njk
@@ -8,6 +8,7 @@
     {% else %}
     <title>Elf. an 11ty project template</title>
     {% endif %}
+    <meta name="description" content="{{ globals.description }}">
     <link rel="stylesheet" href="/assets/core.css">
     <link rel="icon" href="/assets/icons/favicon.svg">
 </head>

--- a/_source/root/documentation.md
+++ b/_source/root/documentation.md
@@ -48,3 +48,14 @@ Useful [front matter](https://www.11ty.dev/docs/data-frontmatter/) attributes:
 - `title` sets the `<title>`-element value and is used to provide a page title
 - `layout` choose one of layouts from `_includes/layouts`
 - `permalink` can be used to override what people see in the address bar; for example `permalink: "documentation/"` will result in `https://elf.moiety.studio/documentation`
+
+## Site settings
+
+<!-- TODO: move to it’s own page? -->
+
+There are a few settings you change to personalise the project:
+
+- `_source/_data/globals.json` contains some variables you can set
+    - `title.short` provides (part of) the `<title>`-element
+    - `title.long` provides the `<title>`-element if no page title (ie. from the markdown file) is provided
+    - `description` is used to set the value for `<meta name="description">`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Elf.",
-  "version": "0.5.3",
-  "description": "Moiety Studio 11ty project template",
+  "version": "0.6.0",
+  "description": "Elf is an 11ty project template to help you start your next 11ty project with ease.",
   "main": "/_source/assets/app.js",
   "scripts": {
     "clean": "npx del _site",


### PR DESCRIPTION
This adds the ability to set a page title and description from a global data file in `_source/_data/globals.json`.

- `title.short` is used for pages that also have a title from the markdown (eg. “Documentation - [title.short]”)
- `title.long` is used for pages where no other title is provided (eg. the home page of Elf has “[title.long]” as it’s title
- `description` is used to populate the description `<meta>`-tag