### PR TITLE
fix(#23): allow code fields to overflow/scroll

### DIFF
--- a/_source/assets/css/basics.css
+++ b/_source/assets/css/basics.css
@@ -1,3 +1,12 @@
+* {
+    box-sizing: border-box;
+}
+
+*::after,
+*::before {
+    box-sizing: inherit;
+}
+
 html,
 body {
     margin: 0;
@@ -6,6 +15,7 @@ body {
 
 body {
     display: grid;
+    grid-template-columns: 100%;
     grid-template-rows: auto 1fr auto;
     color: #fff;
     font-family: "Brendon Text", "Helvetica Neue", sans-serif;

--- a/_source/assets/css/typography.css
+++ b/_source/assets/css/typography.css
@@ -42,6 +42,35 @@ kbd {
     line-height: 1.25;
     background: rgba(244, 190, 206, 0.204);
     background: hsl(from var(--background) h s calc(l + 10));
+    word-break: break-word;
+}
+
+pre {
+    --pre-background: hsl(from var(--background) h s calc(l + 10));
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    background:
+        /* Shadow covers */
+        linear-gradient(to right, var(--pre-background) 25%, rgba(245, 245, 245, 0)),
+        linear-gradient(to left, var(--pre-background) 25%, rgba(245, 245, 245, 0)) 100% 0,
+
+        /* Shadows */
+        linear-gradient(to right, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)),
+        linear-gradient(to left, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 100% 0;
+    background-size:
+        4em 100%,
+        4em 100%,
+        1em 100%,
+        1em 100%;
+    background-attachment:
+        local,
+        local,
+        scroll,
+        scroll;
+    background-repeat: no-repeat;
+    background-color: rgba(244, 190, 206, 0.204);
+    background-color: var(--pre-background);
 }
 
 pre > code {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Elf.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Elf is an 11ty project template to help you start your next 11ty project with ease.",
   "main": "/_source/assets/app.js",
   "scripts": {


### PR DESCRIPTION
Additionally this adds a shadow to the side of pre-blocks that have scrollable content.

Fixes #23 