### PR TITLE
fix(#29): use appropriate units for main grid column

### DIFF
--- a/_source/assets/css/basics.css
+++ b/_source/assets/css/basics.css
@@ -15,7 +15,7 @@ body {
 
 body {
     display: grid;
-    grid-template-columns: 100%;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto 1fr auto;
     color: #fff;
     font-family: "Brendon Text", "Helvetica Neue", sans-serif;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Elf.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Elf is an 11ty project template to help you start your next 11ty project with ease.",
   "main": "/_source/assets/app.js",
   "scripts": {


### PR DESCRIPTION
This was recommended by Mia as being more rigid than `100%` as a value.

Fixes #29 