### PR TITLE
feat(#41): generate menu on build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 import { EleventyI18nPlugin } from "@11ty/eleventy"
+import eleventyNavigationPlugin from "@11ty/eleventy-navigation"
 import postcss from "postcss"
 import postcssImport from "postcss-import"
 import postcssMinify from "postcss-minify"
@@ -17,6 +18,9 @@ export default function(eleventyConfig) {
     eleventyConfig.addFilter("externalLink", (url) => {
         return url.match(/\/*/)[0] != '/'
     })
+    
+    // Plugins --------------------------
+    eleventyConfig.addPlugin(eleventyNavigationPlugin)
     
     // JS processing --------------------
     eleventyConfig.addTemplateFormats("js")

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,3 @@
-import { EleventyI18nPlugin } from "@11ty/eleventy"
 import eleventyNavigationPlugin from "@11ty/eleventy-navigation"
 import postcss from "postcss"
 import postcssImport from "postcss-import"

--- a/_source/_includes/partials/header.njk
+++ b/_source/_includes/partials/header.njk
@@ -6,17 +6,5 @@
         </svg>
     </a>
     
-    <nav aria-label="site" class="core" >
-        <a href="/about">About</a>
-        <a href="/documentation">
-            <span hidden>Docs</span>
-            <span>Documentation</span>
-        </a>
-        <a href="https://github.com/moiety-studio/elf">
-            GitHub
-            <svg role="img" aria-label="(external link)">
-                <use href="/assets/icons/sprite.svg#external-link" />
-            </svg>
-        </a>
-    </nav>
+    {% include "partials/navigation.njk" %}
 </header>

--- a/_source/_includes/partials/navigation.njk
+++ b/_source/_includes/partials/navigation.njk
@@ -1,0 +1,14 @@
+{% set navPages = collections.all | eleventyNavigation %}
+<nav aria-label="site" class="core" >
+{% for entry in navPages %}
+    <a href="{{ entry.url }}"
+       {% if entry.url == page.url %}aria-current="page"{% endif %}>
+        {{ entry.title }}
+        {% if entry.url | externalLink %}
+        <svg role="img" aria-label="(external link)">
+            <use href="/assets/icons/sprite.svg#external-link" />
+        </svg>
+        {% endif %}
+    </a>
+{% endfor %}
+</nav>

--- a/_source/root/about.md
+++ b/_source/root/about.md
@@ -2,6 +2,8 @@
 title: About
 permalink: about/
 layout: "layouts/main.njk"
+eleventyNavigation:
+  key: About
 ---
 
 # About

--- a/_source/root/documentation.md
+++ b/_source/root/documentation.md
@@ -2,6 +2,8 @@
 title: Documentation
 permalink: documentation/
 layout: "layouts/main.njk"
+eleventyNavigation:
+  key: Documentation
 ---
 # Documentation
 

--- a/_source/root/github.md
+++ b/_source/root/github.md
@@ -1,0 +1,6 @@
+---
+eleventyNavigation:
+  key: GitHub
+  url: https://github.com/moiety-studio/elf
+permalink: false
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "Elf.",
-  "version": "0.6.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Elf.",
-      "version": "0.6.1",
+      "version": "0.8.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@11ty/eleventy": "^3.0.0",
+        "@11ty/eleventy-navigation": "^0.3.5",
         "del-cli": "^6.0.0",
         "postcss": "^8.4.49",
         "postcss-import": "^16.1.0",
@@ -123,6 +124,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-navigation": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-0.3.5.tgz",
+      "integrity": "sha512-4aKW5aIQDFed8xs1G1pWcEiFPcDSwZtA4IH1eERtoJ+Xy+/fsoe0pzbDmw84bHZ9ACny5jblENhfZhcCxklqQw==",
+      "license": "MIT",
+      "dependencies": {
+        "dependency-graph": "^0.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-navigation/node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/@11ty/eleventy-plugin-bundle": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
+    "@11ty/eleventy-navigation": "^0.3.5",
     "del-cli": "^6.0.0",
     "postcss": "^8.4.49",
     "postcss-import": "^16.1.0",


### PR DESCRIPTION
This PR implements the official eleventy-navigation plugin.

positives:
- menu is generated from front matter
- less repeating code

negatives:
- having a (mostly) empty file to add an external url feels a bit weird

perhaps we can add an additional method for adding pages? not a big issue though.

Fixes #41