### PR TITLE
feat(#43): increase contrast on <code> elements

### DIFF
--- a/_source/assets/css/_config.css
+++ b/_source/assets/css/_config.css
@@ -16,6 +16,9 @@
     --button-hover-background: hsl(from var(--button-background) h s calc(l + 5));
     --button-active-background: hsl(from var(--button-background) h s calc(l - 5));
 
+    --code-border-color: hsl(from var(--background) h s calc(l + 20));
+    --code-background: hsl(from var(--background) h s calc(l + 10));
+
     /* Sizes */
 }
 
@@ -26,6 +29,9 @@
 
     --button-hover-background: hsl(from var(--background) h s calc(l - 5));
     --button-active-background: hsl(from var(--background) h s calc(l - 10));
+
+    --code-border-color: hsl(from var(--background) h s calc(l - 30));
+    --code-background: hsl(from var(--background) h s calc(l - 10));
 }
 
 [data-selected-theme="aurora"] {

--- a/_source/assets/css/typography.css
+++ b/_source/assets/css/typography.css
@@ -33,26 +33,24 @@ code,
 kbd {
     display: inline-block;
     padding: .125em .25em;
-    border: 1px solid hsl(from var(--background) h s calc(l + 20));
+    border: 1px solid var(--code-border-color);
     border-radius: .25em;
     font-family: "Courier", monospace;
     font-size: .9em;
     font-weight: 700;
     line-height: 1.25;
-    background: rgba(244, 190, 206, 0.204);
-    background: hsl(from var(--background) h s calc(l + 10));
+    background: var(--code-background);
     word-break: break-word;
 }
 
 pre {
-    --pre-background: hsl(from var(--background) h s calc(l + 10));
     display: block;
     max-width: 100%;
     overflow-x: auto;
     background:
         /* Shadow covers */
-        linear-gradient(to right, var(--pre-background) 25%, rgba(245, 245, 245, 0)),
-        linear-gradient(to left, var(--pre-background) 25%, rgba(245, 245, 245, 0)) 100% 0,
+        linear-gradient(to right, var(--code-background) 25%, rgba(245, 245, 245, 0)),
+        linear-gradient(to left, var(--code-background) 25%, rgba(245, 245, 245, 0)) 100% 0,
 
         /* Shadows */
         linear-gradient(to right, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)),
@@ -68,8 +66,7 @@ pre {
         scroll,
         scroll;
     background-repeat: no-repeat;
-    background-color: rgba(244, 190, 206, 0.204);
-    background-color: var(--pre-background);
+    background-color: var(--code-background);
 }
 
 pre > code {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Elf.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Elf is an 11ty project template to help you start your next 11ty project with ease.",
   "main": "/_source/assets/app.js",
   "scripts": {


### PR DESCRIPTION
Improves the contrast ratio of `<code>` elements’ background in the light theme. At 2.1:1 it’s still not great but i’m not sure whether this needs to pass 1.4.11 tbh. the text/code is the main bit and that passes.

Fixes #43 